### PR TITLE
feat(proposal): add viaType field to ExternalApiCreateProposalRequest…

### DIFF
--- a/packages/proposal/src/models/proposal.ts
+++ b/packages/proposal/src/models/proposal.ts
@@ -17,6 +17,13 @@ export interface ExternalApiCreateProposalRequest {
   type: ProposalType;
   metadata?: ProposalMetadata;
   via?: Address;
+  /**
+   * The type of account or mechanism that will execute the proposal:
+   * - 'EOA': An externally owned account (regular wallet)
+   * - 'Safe': A Safe (formerly Gnosis Safe) multi-signature wallet
+   * - 'Gnosis Multisig': A legacy Gnosis multi-signature wallet (not Safe)
+   * - 'Relayer': A Defender Relayer
+   */
   viaType?: 'EOA' | 'Safe' | 'Gnosis Multisig' | 'Relayer';
   functionInterface?: ProposalTargetFunction;
   functionInputs?: ProposalFunctionInputs;


### PR DESCRIPTION
… for account execution types

# Summary

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.

## Summary by Sourcery

New Features:
- Introduce a new optional viaType field to specify the type of account or mechanism executing a proposal, supporting EOA, Safe, Gnosis Multisig, and Relayer execution types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved documentation for proposal creation requests by clarifying the possible values and meanings of the `viaType` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->